### PR TITLE
Meta properties support

### DIFF
--- a/data/anndan.ttl
+++ b/data/anndan.ttl
@@ -14,13 +14,14 @@ prec:Relationships prec:modelAs prec:RDFStarOccurrence .
 
 # <https://example.org/likes> prec:IRIOfRelationship "Likes" .
 
-<https://example.org/likes> prec:IRIOfRelationship [
+[] a prec:RelationshipRule ;
     prec:sourceLabel       "Person" ;
     prec:relationshipLabel "Likes"  ;
+    prec:relationshipIRI <https://example.org/likes> ;
     prec:modelAs prec:RDFReification ;
     prec:subject ex:likedBy ;
     prec:object ex:contentCreator ;
     prec:predicate rdf:type
-] .
+.
 
 <https://schema.org/name> prec:IRIOfProperty "name" .

--- a/prec3/builtin_rules.ttl
+++ b/prec3/builtin_rules.ttl
@@ -71,39 +71,43 @@ prec:object          a prec:SubstitutionTerm ; prec:substitutionTarget rdf:objec
 prec:relationshipIRI a prec:SubstitutionTerm ; prec:substitutionTarget pvar:relationshipIRI .
 prec:propertyIRI     a prec:SubstitutionTerm ; prec:substitutionTarget pvar:propertyKey     .
 
+prec:propertyValue   a prec:SubstitutionTerm ; prec:substitutionTarget pvar:propertyValue .
 
 #################
 # ==== Properties
 
 # - These rules match the pattern
-# pvar:entity   pvar:propertyKey       pvar:property
-# pvar:property rdf:value              pvar:propertyValue
-# pvar:property prec:hasMetaProperties pvar:MetaProperties
+# pvar:entity           pvar:propertyKey       pvar:property
+# pvar:property         rdf:value              pvar:propertyValue
+# pvar:property         a prec:PropertyValue .
+# pvar:property         prec:hasMetaProperties pvar:MetaPropertyNode  # optional
+# pvar:metaPropertyNode pvar:metaPropertyKey   pvar:metaPropertyValue # 0...n
 #
 # For meta properties, the property rule is applied recursively.
 #
 # With:
 # pvar:propertyKey   a prec:PropertyKey   .
-# pvar:property      a prec:PropertyValue .
 
 
 # prec:PropertyTransformation patterns must:
-# - Keep entity in subject position
-# - prec:receiveFrom appear at most once
+# - Keep entity in subject position (or subject-subject, ...)
+# - pvar:metaPropertyKey and pvar:metaPropertyValue are only usable in triples
+# of form << ?s pvar:metaPropertyKey pvar:metaPropertyValue >>
+# - Embedded triples used in property model must be asserted.
 
 prec:Prec0Property a prec:PropertyTransformation ;
   prec:composedOf
-    << pvar:entity   pvar:propertyKey       pvar:property >> ,
-    << pvar:property rdf:value              pvar:propertyValue  >>
-# , << pvar:property prec:hasMetaProperties pvar:MetaProperties >>
-  .
-
+    << pvar:entity           pvar:propertyKey       pvar:property          >> ,
+    << pvar:property         rdf:value              pvar:propertyValue     >> ,
+    << pvar:property         rdf:type               prec:PropertyValue     >> ,
+    << pvar:property         prec:hasMetaProperties pvar:metaPropertyNode  >> ,
+    << pvar:metaPropertyNode pvar:metaPropertyKey   pvar:metaPropertyValue >> .
 
 prec:DirectTriples a prec:PropertyTransformation ;
   prec:composedOf
-    <<    pvar:entity pvar:propertyKey pvar:propertyValue    >>
-# , << << pvar:entity pvar:propertyKey pvar:propertyValue >> prec:receiveFrom pvar:MetaProperties >>    
-  ; rdfs:comment
+    <<    pvar:entity pvar:propertyKey pvar:propertyValue >> ,
+    << << pvar:entity pvar:propertyKey pvar:propertyValue >> pvar:metaPropertyKey pvar:metaPropertyValue >> ;
+  rdfs:comment
     """
     This model shold not be used if a node or an edge has a multi valued
     property with at least twice the same value.
@@ -112,8 +116,7 @@ prec:DirectTriples a prec:PropertyTransformation ;
 
 prec:CombinedBlankNodes a prec:PropertyTransformation ;
   prec:composedOf
-    << pvar:entity   pvar:propertyKey pvar:property       >> ,
-    << pvar:property rdf:value        pvar:propertyValue  >>
-# , << pvar:property prec:receiveFrom pvar:MetaProperties >>
-  .
-
+    << pvar:entity   pvar:propertyKey     pvar:property          >> ,
+    << pvar:property rdf:value            pvar:propertyValue     >> ,
+    << pvar:property rdf:type             prec:PropertyValue     >> ,
+    << pvar:property pvar:metaPropertyKey pvar:metaPropertyValue >> .

--- a/prec3/context-loader.js
+++ b/prec3/context-loader.js
@@ -234,6 +234,25 @@ function _throwIfInvalidPropertyModels(models) {
             }
         });
     });
+
+    models.get(prec.RelationshipProperties).forEach(
+        (modelName, targetModel) => {
+            const invalidTriple = targetModel.find(triple => {
+                return undefined !== ["subject", "predicate", "object", "graph"].find(role => {
+                    const embedded = triple[role];
+                    if (embedded.termType !== 'Quad') return false;
+                    return undefined === targetModel.find(assertedTriple => assertedTriple.equals(embedded));
+                });
+            });
+
+            const hasInvalidTriple = invalidTriple !== undefined;
+            if (hasInvalidTriple) {
+                throw Error("Property Model checker: the model " + modelName.value
+                + " is used as a property model for relationships but contains an"
+                + " embedded triple that is not asserted by the model.");
+            }
+        }
+    );
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,130 @@ describe('StoreAlterer', function() {
 
         })
 
+        describe('evilFindAndReplace', function() {
+            it("should work as usual on non rdf-star datasets with non rdf star patterns", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                        ex:s  ex:p1 ex:o .
+                        ex:s  ex:p2 ex:o .
+                        ex:s1 ex:p1 ex:o .
+                        ex:s2 ex:p2 ex:otherO .
+                    `
+                );
+
+                dstar.evilFindAndReplace(
+                    {},
+                    [$quad(variable('s'), ex.p1, variable('o'))],
+                    [$quad(variable('o'), ex.p1, variable('s'))]
+                );
+
+                assert.strictEqual(dstar.size, 4);
+
+                assert.ok(dstar.has($quad(ex.s , ex.p2, ex.o)));
+                assert.ok(dstar.has($quad(ex.s2, ex.p2, ex.otherO)));
+
+                assert.ok(dstar.has($quad(ex.o , ex.p1, ex.s)));
+                assert.ok(dstar.has($quad(ex.o , ex.p1, ex.s1)));
+            })
+
+            it("should work on rdf star datasets for which the evil part is not used", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                        ex:s    ex:p  ex:o .
+                        ex:toto ex:says << ex:toto ex:says ex:unicorn >> .
+                    `
+                );
+
+                dstar.evilFindAndReplace(
+                    {},
+                    [$quad(variable('s'), ex.p, variable('o'))],
+                    [$quad(variable('o'), ex.p, variable('s'))]
+                );
+
+                assert.strictEqual(dstar.size, 2);
+
+                assert.ok( dstar.has($quad(ex.o, ex.p, ex.s)));
+                assert.ok(!dstar.has($quad(ex.s, ex.p, ex.o)));
+            })
+
+            it("should work on rdf star datasets for which the evil part is used properly", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                                           ex:john ex:in ex:wonderland    .
+                        ex:toto ex:says << ex:john ex:in ex:wonderland >> .
+                    `
+                );
+
+                dstar.evilFindAndReplace(
+                    {},
+                    [$quad(variable('john'), ex.in, ex.wonderland)],
+                    [$quad(ex.alice        , ex.in, ex.wonderland)]
+                );
+
+                assert.strictEqual(dstar.size, 2);
+
+                assert.ok(dstar.has(                        $quad(ex.alice, ex.in, ex.wonderland)) );
+                assert.ok(dstar.has($quad(ex.toto, ex.says, $quad(ex.alice, ex.in, ex.wonderland))));
+            })
+
+            it("should refuse to work with an invalid corresponding pattern", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                                           ex:john ex:in ex:wonderland    .
+                        ex:toto ex:says << ex:john ex:in ex:wonderland >> .
+                    `
+                );
+
+                try {
+                    dstar.evilFindAndReplace(
+                        {},
+                        [$quad(variable('john'), ex.in, ex.wonderland)],
+                        []
+                    );
+                    assert.ok(false, "should have thrown because no associated triple")
+                } catch (e) {
+                    assert.ok(true);
+                }
+            })
+            
+            it("should work on rdf star datasets for which the evil part is used properly (composed source and model)", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                                           ex:john ex:in ex:wonderland    .
+                        ex:toto ex:says << ex:john ex:in ex:wonderland >> .
+                        ex:john ex:is ex:Person .
+                    `
+                );
+
+                dstar.evilFindAndReplace(
+                    {},
+                    [
+                        $quad(variable('john'), ex.is, ex.Person),
+                        $quad(variable('john'), ex.in, ex.wonderland)
+                    ],
+                    [
+                        $quad(ex.alice        , ex.in, ex.wonderland),
+                        $quad(variable('john'), ex.is, ex.Imposter)
+                    ]
+                );
+
+                assert.strictEqual(dstar.size, 3);
+
+                assert.ok(dstar.has(                        $quad(ex.alice, ex.in, ex.wonderland)) );
+                assert.ok(dstar.has($quad(ex.toto, ex.says, $quad(ex.alice, ex.in, ex.wonderland))));
+                assert.ok(dstar.has($quad(ex.john, ex.is, ex.Imposter)));
+            })
+        });
     })
 });
 


### PR DESCRIPTION
- [x] A model can now be applied to meta properties 
- [ ] When the relationship model removes pvar:self, the system is able modify the nested quad that used pvar:self