### PR TITLE
Meta properties support

### DIFF
--- a/data/anndan.ttl
+++ b/data/anndan.ttl
@@ -14,13 +14,14 @@ prec:Relationships prec:modelAs prec:RDFStarOccurrence .
 
 # <https://example.org/likes> prec:IRIOfRelationship "Likes" .
 
-<https://example.org/likes> prec:IRIOfRelationship [
+[] a prec:RelationshipRule ;
     prec:sourceLabel       "Person" ;
     prec:relationshipLabel "Likes"  ;
+    prec:relationshipIRI <https://example.org/likes> ;
     prec:modelAs prec:RDFReification ;
     prec:subject ex:likedBy ;
     prec:object ex:contentCreator ;
     prec:predicate rdf:type
-] .
+.
 
 <https://schema.org/name> prec:IRIOfProperty "name" .

--- a/dataset/index.js
+++ b/dataset/index.js
@@ -176,6 +176,11 @@ class Dataset {
 
         return [...inStore, ...inArray];
     }
+
+    /** Return an array with every quad that contains a nested triple */
+    getRDFStarQuads() {
+        return [...this.starQuads];
+    }
     
     /** Removes */
     removeQuads(quads) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -204,7 +204,7 @@
                 # We want the destination to be the source and the destination
                 # to be the source so let's write our own model!
                 prec:modelAs [
-                  a prec:EdgeTransformation ;
+                  a prec:RelationshipModel ;
                   prec:composedOf
                     # Assert the triple
                     <<    pvar:destination pvar:relationshipIRI pvar:source               >> ,
@@ -674,15 +674,11 @@
           </section>
 
           <section>
-            <h5><dfn data-lt="prec:EdgeTransformation">http://bruy.at/prec#EdgeTransformation</dfn></h5>
-
-            <aside class="warning">
-              TODO: EdgeTransformation should be named RelationshipModel
-            </aside>
+            <h5><dfn data-lt="prec:RelationshipModel">http://bruy.at/prec#RelationshipModel</dfn></h5>
 
             <p>The type of models that can be used for relationships.</p>
 
-            <p>`EdgeTransformation`s use the following variable:</p>
+            <p>`RelationshipModel`s use the following variable:</p>
             <ul>
               <li>`pvar:self`: The RDF node that was created to identify the relationship.</li>
               <li>`pvar:source`: The RDF node that represents the PG source node of the relationship.</li>
@@ -696,13 +692,13 @@
               We are going to show how a user can define its own model
 
             <aside class="example">
-              <p>An [= prec:EdgeTransformation =] that is the identity / the standard RDF Reification</p>
+              <p>An [= prec:RelationshipModel =] that is the identity / the standard RDF Reification</p>
               <pre data-transform="updateExample"
                  data-content-type="text/turtle"
                  class="nohighlight"
               >
                 <!--
-                prec:RDFReification a prec:EdgeTransformation ;
+                prec:RDFReification a prec:RelationshipModel ;
                   prec:composedOf
                     << pvar:self a pgo:Edge >> ,
                     << pvar:self rdf:subject      pvar:source          >> ,
@@ -730,7 +726,7 @@
                  class="nohighlight"
               >
                 <!--
-                prec:RdfStarUnique a prec:EdgeTransformation ;
+                prec:RdfStarUnique a prec:RelationshipModel ;
                   prec:composedOf
                     <<    pvar:source pvar:relationshipIRI pvar:destination               >> , # (a)
                     << << pvar:source pvar:relationshipIRI pvar:destination >> a pgo:Edge >> , # (b)
@@ -785,15 +781,15 @@
           </section>
 
           <section>
-            <h5><dfn data-lt="prec:PropertyTransformation">http://bruy.at/prec#PropertyTransformation</dfn></h5>
+            <h5><dfn data-lt="prec:PropertyModel">http://bruy.at/prec#PropertyModel</dfn></h5>
 
             <p>The type of models that can be used for properties.</p>
             
             <aside class="warning">
-              <p>TODO: PropertyTransformation should be named PropertyModel</p>
+              <p>TODO: PropertyModel should be named PropertyModel</p>
             </aside>
 
-            <p>`prec:PropertyTransformation`s use the following variables:</p>
+            <p>`prec:PropertyModel`s use the following variables:</p>
             <ul>
               <li>`pvar:entity`: The RDF node that was created to identify the edge of the node.</li>
               <li>`pvar:propertyKey`: The node that represents the edge label.</li>
@@ -806,7 +802,7 @@
 
             <p>
               The substitution mecanism is the same as described in the
-              [= prec:EdgeTransformation =] section.
+              [= prec:RelationshipModel =] section.
             </p>
 
             <p>Some restrictions exists on property models:

--- a/docs/index.html
+++ b/docs/index.html
@@ -92,7 +92,13 @@
 
       <section>
         <h3>Schema of the PREC-0 graphs</h3>
-        <p>TODO</p>
+        <p>
+          A partial SHACL Shapes Graph is available at
+          <a href="https://github.com/BruJu/PREC/blob/master/docs/prec0shape.ttl">
+            https://github.com/BruJu/PREC/blob/master/docs/prec0shape.ttl
+          </a>. This SHACL Shapes Graph should be conform on every PREC-0
+          generated graph (graphs extracted by PREC without any context).
+        </p>
       </section>
 
       <section>
@@ -116,7 +122,146 @@
       <section>
         <h3>Example of a context</h3>
 
-        <p>TODO</p>
+        <aside class="example">
+          <p>
+            In this section, we will present the ontology through a practical
+            example. Considering a property graph with the following data
+            (exposed in a format similar to a Cypher query):
+          </p>
+
+          <pre>
+            ( haddock   :Person { name: "Haddock", firstName: "Archibald" } ),
+            ( snowy     :Animal { name: "Snowy"  } ),
+            ( the_serie :Serie  { name: "The Adventures of Tintin" } ),
+
+            ( haddock ) -[ :appears { since: "The Crab with the Golden Claws"   } ]->( the_serie ),
+            ( snowy   ) -[ :appears { since: "Tintin in the Land of the Soviets" }]->( the_serie ),
+            ( haddock ) -[ :knows ]->( snowy )
+          </pre>
+
+          <p>
+            PREC enables us to convert this Property Graph into an RDF graph.
+            The graph generated without any context is very verbose, and will
+            not be displayed here. Instead, we are going to write a context to
+            produce a small and readable graph.
+          </p>
+
+          <pre data-transform="updateExample"
+            data-content-type="text/turtle"
+            class="nohighlight"
+          >
+            <!--
+              @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+              @prefix prec: <http://bruy.at/prec#> .
+              @prefix pvar: <http://bruy.at/prec-trans#> .
+              @prefix pgo:  <http://ii.uwb.edu.pl/pgo#> .
+
+              # We want properties to be written in the RDF-graph as
+              # [the node or relationship] [iri of the property] [the value]
+              prec:Properties prec:modelAs prec:DirectTriples .
+
+              # We want relationships to be written in the RDF-graph as
+              # [the source] [the label] [the destination]
+              # and use RDF-star for properties
+              prec:Relationships prec:modelAs prec:RdfStarUnique .
+
+              # == Properties
+
+              # The name of a person is its family name
+              [] a prec:PropertyRule ;
+                prec:propertyName "name" ;
+                prec:propertyIRI <http://schema.org/familyName> ;
+                prec:nodeLabel "Person" .
+              
+              [] a prec:PropertyRule ;
+                prec:propertyName "firstName" ;
+                prec:propertyIRI <http://schema.org/givenName> .
+
+              # Other names are names
+              [] a prec:PropertyRule ;
+                prec:propertyName "name" ;
+                prec:propertyIRI <http://schema.org/name> .
+              
+              # We use an IRI from dbpedia for since
+              # As writing rules for simples things is very long, we are
+              # going to use a syntatctic sugar
+              <http://dbpedia.org/property/debut> prec:IRIOfProperty "since" .
+
+              # == Node labels
+              <http://dbpedia.org/resource/Person> prec:IRIOfNodeLabel "Person" .
+              <http://dbpedia.org/resource/Animal> prec:IRIOfNodeLabel "Animal" .
+              <http://dbpedia.org/class/yago/Series108457976> prec:IRIOfNodeLabel "Serie" .
+
+              # == Relationships
+              <http://schema.org/knowsAbout> prec:IRIOfRelationship "knows" .
+              <http://schema.org/knowsAbout> prec:IRIOfRelationship "knows" .
+
+              # Map appears to schema:character. One problem of schema:character
+              # is that is expect the serie as the subject and the character as
+              # an object, but we can fix the order!
+              [] a prec:RelationshipRule ;
+                prec:relationshipLabel "appears" ;
+                # We want the destination to be the source and the destination
+                # to be the source so let's write our own model!
+                prec:modelAs [
+                  a prec:EdgeTransformation ;
+                  prec:composedOf
+                    # Assert the triple
+                    <<    pvar:destination pvar:relationshipIRI pvar:source               >> ,
+                    # Keep the provenance
+                    << << pvar:destination pvar:relationshipIRI pvar:source >> a pgo:Edge >> ,
+                    # Keep the properties
+                    << << pvar:destination pvar:relationshipIRI pvar:source >> pvar:propertyKey pvar:propertyValue >> 
+                ] ;
+                # prec:relationshipIRI will actually replace pvar:relationship with schema:character
+                prec:relationshipIRI <http://schema.org/character> .
+            -->
+          </pre>
+
+          <p>
+            The produce RDF-graph will be isomorphic to be following:
+          </p>
+
+          <pre data-transform="updateExample"
+            data-content-type="text/turtle"
+            class="nohighlight"
+          >
+            <!--
+            # Note that Haddock have no http://schema.org/name
+            _:haddock a pgo:Node, <http://dbpedia.org/resource/Person>;
+                <http://schema.org/givenName> "Archibald";
+                <http://schema.org/familyName> "Haddock".
+            
+            _:snowy a pgo:Node, <http://dbpedia.org/resource/Animal>;
+                <http://schema.org/name> "Snowy".
+            
+            _:adventures_of_tintin a pgo:Node, <http://dbpedia.org/class/yago/Series108457976>;
+                <http://schema.org/name> "The Adventures of Tintin";
+                # The relationship have been properly inverted
+                <http://schema.org/character> _:haddock, _:snowy.     
+
+            _:haddock <http://schema.org/knowsAbout> _:snowy.
+            <<_:haddock <http://schema.org/knowsAbout> _:snowy>> a pgo:Edge.
+              
+            # When did every character appear?
+            <<_:adventures_of_tintin <http://schema.org/character> _:haddock>> a pgo:Edge;
+                <http://dbpedia.org/property/debut> "The Crab with the Golden Claws".
+
+            <<_:adventures_of_tintin <http://schema.org/character> _:snowy>> a pgo:Edge;
+                <http://dbpedia.org/property/debut> "Tintin in the Land of the Soviets".
+            -->
+          </pre>
+
+          <p>
+            Note that in this example, while the produced output is easy to
+            read and reuse existing ontologies, we are not conforming to the DBPedia
+            usual schema, as in DBpedia, `<http://dbpedia.org/property/debut>`
+            would be used with the character as the subject and the book (and
+            not its name) as the object ; and in the current state of the
+            ontology we can not do better. This is one of the weakness of
+            the ontology: it can not conform to every schema.
+          </p>
+        </aside>
       </section>
     </section>
 
@@ -431,9 +576,10 @@
 
             <p>
               The domain of every properties. A triple that has
-              [= prec:Properties =] as a subject is equivalent to two triples,
-              one with [= prec:NodeProperties =] as the subject and another with
-              [= prec:RelationshipProperties =] as the subject.
+              [= prec:Properties =] as a subject is equivalent to three triples,
+              one with [= prec:NodeProperties =] as the subject, another with
+              [= prec:RelationshipProperties =] as the subject and another
+              with [= prec:MetaProperties =] as the subject.
             </p>
           </section>
 
@@ -454,6 +600,14 @@
           </section>
 
           <section>
+            <h5><dfn data-lt="prec:MetaProperties">http://bruy.at/prec#MetaProperties</dfn></h5>
+
+            <p>
+              The domain of every meta properties (properties on properties).
+            </p>
+          </section>
+
+          <section>
             <h5><dfn data-lt="prec:Prec0Property">http://bruy.at/prec#Prec0Property</dfn></h5>
 
             <p>
@@ -461,10 +615,6 @@
               [= prec:hasMetaProperties =] example. This is the default
               behaviour.
             </p>
-
-            <aside class="warning">
-              <p><em>This mode may not be the default behaviour in the future.</em></p>
-            </aside>
           </section>
 
           <section>
@@ -502,6 +652,13 @@
             without actually using a real variable.
           </p>
 
+          <aside class="note">
+            <p>
+              Every built-in model is actually defined in a turtle file that
+              is loaded and included to every context you write.
+            </p>
+          </aside>
+
           <section>
             <h5><dfn data-lt="prec:composedOf">http://bruy.at/prec#composedOf</dfn></h5>
 
@@ -536,7 +693,7 @@
             </ul>
 
             <p>
-              We are going to show how an user can define its own model
+              We are going to show how a user can define its own model
 
             <aside class="example">
               <p>An [= prec:EdgeTransformation =] that is the identity / the standard RDF Reification</p>
@@ -635,10 +792,6 @@
             <aside class="warning">
               <p>TODO: PropertyTransformation should be named PropertyModel</p>
             </aside>
-            
-            <aside class="warning">
-              <p>Meta properties are not yet supported.</p>
-            </aside>
 
             <p>`prec:PropertyTransformation`s use the following variables:</p>
             <ul>
@@ -646,15 +799,42 @@
               <li>`pvar:propertyKey`: The node that represents the edge label.</li>
               <li>`pvar:property`: The blank node that represents the property.</li>
               <li>`pvar:propertyValue`: The literal that contains the property value.</li>
+              <li>`pvar:metaPropertyNode`: The blank node that contains every meta property, as described in [= prec:hasMetaProperties =]</li>
+              <li>`pvar:metaPropertyKey`: The predicate of a meta property triple.</li>
+              <li>`pvar:metaPropertyValue`: The object of a meta property triple.</li>
             </ul>
 
             <p>
               The substitution mecanism is the same as described in the
               [= prec:EdgeTransformation =] section.
             </p>
+
+            <p>Some restrictions exists on property models:
+              <ul>
+                <li>
+                  `pvar:entity` can only appear in the "subject-star" position.
+                  The `subject-star` position is defined recursively as either
+                  the subject of the quad if it is not a nested quad, or the
+                  "subject-star" of the quad in the subject position. In other
+                  words, when the Triple-star is written in the N-Triples-star
+                  format, it is the first non RDF-star term that appears for
+                  this triple.
+                </li>
+                <li>
+                  Every embedded triple must be asserted by the model.
+                </li>
+                <li>
+                  `pvar:metaPropertyKey` and `pvar:metaPropertyValue`, if they
+                  appear, must appear both at the same time, and as repectively
+                  the predicate and the object.
+                </li>
+              </ul>
+            </p>
+            <p>
+              These restriction exists to make between combinaisons a
+              relationship model and different property models possible.
+            </p>
           </section>
-
-
         </section>
 
       <section>
@@ -1003,7 +1183,7 @@
           </section>
 
           <section>
-            <h5><dfn data-lt="prec:relationshipLabel (used in a property rule)">http://bruy.at/prec#propertyLabel</dfn></h5>
+            <h5><dfn data-lt="prec:relationshipLabel (used in a property rule)">http://bruy.at/prec#relationshipLabel (in a property Rule)</dfn></h5>
 
             <p>
               States the label that the relationship must have for the rule to

--- a/prec3/builtin_rules.ttl
+++ b/prec3/builtin_rules.ttl
@@ -24,7 +24,7 @@ PREFIX pgo:   <http://ii.uwb.edu.pl/pgo#>
 
 # Encoding as standard RDF Reificaiton. It is the default pattern, so this
 # target is not useful in this form.
-prec:RDFReification a prec:EdgeTransformation ;
+prec:RDFReification a prec:RelationshipModel ;
   prec:composedOf
     << pvar:self a pgo:Edge >> ,
     << pvar:self rdf:subject      pvar:source          >> ,
@@ -34,7 +34,7 @@ prec:RDFReification a prec:EdgeTransformation ;
   .
 
 # Encoding as RDF star using regular RDF triples that can be annotated
-prec:RdfStarUnique a prec:EdgeTransformation ;
+prec:RdfStarUnique a prec:RelationshipModel ;
   prec:composedOf
     <<    pvar:source pvar:relationshipIRI pvar:destination               >> ,
     << << pvar:source pvar:relationshipIRI pvar:destination >> a pgo:Edge >> ,
@@ -42,7 +42,7 @@ prec:RdfStarUnique a prec:EdgeTransformation ;
   .
 
 # Encoding as RDF star using occurrences
-prec:RdfStarOccurrence a prec:EdgeTransformation ;
+prec:RdfStarOccurrence a prec:RelationshipModel ;
   prec:composedOf
     << pvar:self prec:occurrenceOf << pvar:source pvar:relationshipIRI pvar:destination >> >> ,
     << pvar:self a pgo:Edge >> ,
@@ -50,7 +50,7 @@ prec:RdfStarOccurrence a prec:EdgeTransformation ;
   .
 
 # Encoding as singleton property
-prec:SingletonProperty a prec:EdgeTransformation ;
+prec:SingletonProperty a prec:RelationshipModel ;
   prec:composedOf
     << pvar:source pvar:self               pvar:destination     >> ,
     << pvar:self   rdf:singletonPropertyOf pvar:relationshipIRI >> ,
@@ -89,13 +89,13 @@ prec:propertyValue   a prec:SubstitutionTerm ; prec:substitutionTarget pvar:prop
 # pvar:propertyKey   a prec:PropertyKey   .
 
 
-# prec:PropertyTransformation patterns must:
+# prec:PropertyModel patterns must:
 # - Keep entity in subject position (or subject-subject, ...)
 # - pvar:metaPropertyKey and pvar:metaPropertyValue are only usable in triples
 # of form << ?s pvar:metaPropertyKey pvar:metaPropertyValue >>
 # - Embedded triples used in property model must be asserted.
 
-prec:Prec0Property a prec:PropertyTransformation ;
+prec:Prec0Property a prec:PropertyModel ;
   prec:composedOf
     << pvar:entity           pvar:propertyKey       pvar:property          >> ,
     << pvar:property         rdf:value              pvar:propertyValue     >> ,
@@ -103,7 +103,7 @@ prec:Prec0Property a prec:PropertyTransformation ;
     << pvar:property         prec:hasMetaProperties pvar:metaPropertyNode  >> ,
     << pvar:metaPropertyNode pvar:metaPropertyKey   pvar:metaPropertyValue >> .
 
-prec:DirectTriples a prec:PropertyTransformation ;
+prec:DirectTriples a prec:PropertyModel ;
   prec:composedOf
     <<    pvar:entity pvar:propertyKey pvar:propertyValue >> ,
     << << pvar:entity pvar:propertyKey pvar:propertyValue >> pvar:metaPropertyKey pvar:metaPropertyValue >> ;
@@ -114,7 +114,7 @@ prec:DirectTriples a prec:PropertyTransformation ;
     """@en
     .
 
-prec:CombinedBlankNodes a prec:PropertyTransformation ;
+prec:CombinedBlankNodes a prec:PropertyModel ;
   prec:composedOf
     << pvar:entity   pvar:propertyKey     pvar:property          >> ,
     << pvar:property rdf:value            pvar:propertyValue     >> ,

--- a/prec3/builtin_rules.ttl
+++ b/prec3/builtin_rules.ttl
@@ -71,39 +71,43 @@ prec:object          a prec:SubstitutionTerm ; prec:substitutionTarget rdf:objec
 prec:relationshipIRI a prec:SubstitutionTerm ; prec:substitutionTarget pvar:relationshipIRI .
 prec:propertyIRI     a prec:SubstitutionTerm ; prec:substitutionTarget pvar:propertyKey     .
 
+prec:propertyValue   a prec:SubstitutionTerm ; prec:substitutionTarget pvar:propertyValue .
 
 #################
 # ==== Properties
 
 # - These rules match the pattern
-# pvar:entity   pvar:propertyKey       pvar:property
-# pvar:property rdf:value              pvar:propertyValue
-# pvar:property prec:hasMetaProperties pvar:MetaProperties
+# pvar:entity           pvar:propertyKey       pvar:property
+# pvar:property         rdf:value              pvar:propertyValue
+# pvar:property         a prec:PropertyValue .
+# pvar:property         prec:hasMetaProperties pvar:MetaPropertyNode  # optional
+# pvar:metaPropertyNode pvar:metaPropertyKey   pvar:metaPropertyValue # 0...n
 #
 # For meta properties, the property rule is applied recursively.
 #
 # With:
 # pvar:propertyKey   a prec:PropertyKey   .
-# pvar:property      a prec:PropertyValue .
 
 
 # prec:PropertyTransformation patterns must:
-# - Keep entity in subject position
-# - prec:receiveFrom appear at most once
+# - Keep entity in subject position (or subject-subject, ...)
+# - pvar:metaPropertyKey and pvar:metaPropertyValue are only usable in triples
+# of form << ?s pvar:metaPropertyKey pvar:metaPropertyValue >>
+# - Embedded triples used in property model must be asserted.
 
 prec:Prec0Property a prec:PropertyTransformation ;
   prec:composedOf
-    << pvar:entity   pvar:propertyKey       pvar:property >> ,
-    << pvar:property rdf:value              pvar:propertyValue  >>
-# , << pvar:property prec:hasMetaProperties pvar:MetaProperties >>
-  .
-
+    << pvar:entity           pvar:propertyKey       pvar:property          >> ,
+    << pvar:property         rdf:value              pvar:propertyValue     >> ,
+    << pvar:property         rdf:type               prec:PropertyValue     >> ,
+    << pvar:property         prec:hasMetaProperties pvar:metaPropertyNode  >> ,
+    << pvar:metaPropertyNode pvar:metaPropertyKey   pvar:metaPropertyValue >> .
 
 prec:DirectTriples a prec:PropertyTransformation ;
   prec:composedOf
-    <<    pvar:entity pvar:propertyKey pvar:propertyValue    >>
-# , << << pvar:entity pvar:propertyKey pvar:propertyValue >> prec:receiveFrom pvar:MetaProperties >>    
-  ; rdfs:comment
+    <<    pvar:entity pvar:propertyKey pvar:propertyValue >> ,
+    << << pvar:entity pvar:propertyKey pvar:propertyValue >> pvar:metaPropertyKey pvar:metaPropertyValue >> ;
+  rdfs:comment
     """
     This model shold not be used if a node or an edge has a multi valued
     property with at least twice the same value.
@@ -112,8 +116,7 @@ prec:DirectTriples a prec:PropertyTransformation ;
 
 prec:CombinedBlankNodes a prec:PropertyTransformation ;
   prec:composedOf
-    << pvar:entity   pvar:propertyKey pvar:property       >> ,
-    << pvar:property rdf:value        pvar:propertyValue  >>
-# , << pvar:property prec:receiveFrom pvar:MetaProperties >>
-  .
-
+    << pvar:entity   pvar:propertyKey     pvar:property          >> ,
+    << pvar:property rdf:value            pvar:propertyValue     >> ,
+    << pvar:property rdf:type             prec:PropertyValue     >> ,
+    << pvar:property pvar:metaPropertyKey pvar:metaPropertyValue >> .

--- a/prec3/context-loader.js
+++ b/prec3/context-loader.js
@@ -234,6 +234,25 @@ function _throwIfInvalidPropertyModels(models) {
             }
         });
     });
+
+    models.get(prec.RelationshipProperties).forEach(
+        (modelName, targetModel) => {
+            const invalidTriple = targetModel.find(triple => {
+                return undefined !== ["subject", "predicate", "object", "graph"].find(role => {
+                    const embedded = triple[role];
+                    if (embedded.termType !== 'Quad') return false;
+                    return undefined === targetModel.find(assertedTriple => assertedTriple.equals(embedded));
+                });
+            });
+
+            const hasInvalidTriple = invalidTriple !== undefined;
+            if (hasInvalidTriple) {
+                throw Error("Property Model checker: the model " + modelName.value
+                + " is used as a property model for relationships but contains an"
+                + " embedded triple that is not asserted by the model.");
+            }
+        }
+    );
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/prec_context.js
+++ b/test/prec_context.js
@@ -3,7 +3,6 @@ const utility = require("./utility.js");
 const graphReducer = require("../prec3/graph-reducer.js");
 const assert = require('assert');
 const { isomorphic } = require("rdf-isomorphic");
-const { isSubstituableGraph } = require('../graph-substitution.js');
 const precUtils = require('../prec3/utils.js')
 
 
@@ -168,7 +167,7 @@ function runATest(graphName, contextName, expected) {
         graphReducer(store, context);
 
         const expectedStore = utility.turtleToDStar(expected);
-        const r = isSubstituableGraph(store.getQuads(), expectedStore.getQuads());
+        const r = isomorphic(store.getQuads(), expectedStore.getQuads());
         if (!r) print(store, basicGraphs, graphName, contexts, contextName, expectedStore);
         assert.ok(r);
     });
@@ -183,8 +182,6 @@ function runATest_(dict, graphName, contextName, expected) {
 
         const expectedStore = utility.turtleToDStar(expected);
         const r = isomorphic(store.getQuads(), expectedStore.getQuads());
-
-        //const r = isSubstituableGraph(store.getQuads(), expectedStore.getQuads());
         if (!r) print(store, dict, graphName, dict, contextName, expectedStore);
         assert.ok(r);
     });

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,130 @@ describe('StoreAlterer', function() {
 
         })
 
+        describe('evilFindAndReplace', function() {
+            it("should work as usual on non rdf-star datasets with non rdf star patterns", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                        ex:s  ex:p1 ex:o .
+                        ex:s  ex:p2 ex:o .
+                        ex:s1 ex:p1 ex:o .
+                        ex:s2 ex:p2 ex:otherO .
+                    `
+                );
+
+                dstar.evilFindAndReplace(
+                    {},
+                    [$quad(variable('s'), ex.p1, variable('o'))],
+                    [$quad(variable('o'), ex.p1, variable('s'))]
+                );
+
+                assert.strictEqual(dstar.size, 4);
+
+                assert.ok(dstar.has($quad(ex.s , ex.p2, ex.o)));
+                assert.ok(dstar.has($quad(ex.s2, ex.p2, ex.otherO)));
+
+                assert.ok(dstar.has($quad(ex.o , ex.p1, ex.s)));
+                assert.ok(dstar.has($quad(ex.o , ex.p1, ex.s1)));
+            })
+
+            it("should work on rdf star datasets for which the evil part is not used", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                        ex:s    ex:p  ex:o .
+                        ex:toto ex:says << ex:toto ex:says ex:unicorn >> .
+                    `
+                );
+
+                dstar.evilFindAndReplace(
+                    {},
+                    [$quad(variable('s'), ex.p, variable('o'))],
+                    [$quad(variable('o'), ex.p, variable('s'))]
+                );
+
+                assert.strictEqual(dstar.size, 2);
+
+                assert.ok( dstar.has($quad(ex.o, ex.p, ex.s)));
+                assert.ok(!dstar.has($quad(ex.s, ex.p, ex.o)));
+            })
+
+            it("should work on rdf star datasets for which the evil part is used properly", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                                           ex:john ex:in ex:wonderland    .
+                        ex:toto ex:says << ex:john ex:in ex:wonderland >> .
+                    `
+                );
+
+                dstar.evilFindAndReplace(
+                    {},
+                    [$quad(variable('john'), ex.in, ex.wonderland)],
+                    [$quad(ex.alice        , ex.in, ex.wonderland)]
+                );
+
+                assert.strictEqual(dstar.size, 2);
+
+                assert.ok(dstar.has(                        $quad(ex.alice, ex.in, ex.wonderland)) );
+                assert.ok(dstar.has($quad(ex.toto, ex.says, $quad(ex.alice, ex.in, ex.wonderland))));
+            })
+
+            it("should refuse to work with an invalid corresponding pattern", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                                           ex:john ex:in ex:wonderland    .
+                        ex:toto ex:says << ex:john ex:in ex:wonderland >> .
+                    `
+                );
+
+                try {
+                    dstar.evilFindAndReplace(
+                        {},
+                        [$quad(variable('john'), ex.in, ex.wonderland)],
+                        []
+                    );
+                    assert.ok(false, "should have thrown because no associated triple")
+                } catch (e) {
+                    assert.ok(true);
+                }
+            })
+            
+            it("should work on rdf star datasets for which the evil part is used properly (composed source and model)", function() {
+                const dstar = new DStar();
+                dstar.addFromTurtleStar(
+                    `
+                        @prefix ex: <http://example.org/> .
+                                           ex:john ex:in ex:wonderland    .
+                        ex:toto ex:says << ex:john ex:in ex:wonderland >> .
+                        ex:john ex:is ex:Person .
+                    `
+                );
+
+                dstar.evilFindAndReplace(
+                    {},
+                    [
+                        $quad(variable('john'), ex.is, ex.Person),
+                        $quad(variable('john'), ex.in, ex.wonderland)
+                    ],
+                    [
+                        $quad(ex.alice        , ex.in, ex.wonderland),
+                        $quad(variable('john'), ex.is, ex.Imposter)
+                    ]
+                );
+
+                assert.strictEqual(dstar.size, 3);
+
+                assert.ok(dstar.has(                        $quad(ex.alice, ex.in, ex.wonderland)) );
+                assert.ok(dstar.has($quad(ex.toto, ex.says, $quad(ex.alice, ex.in, ex.wonderland))));
+                assert.ok(dstar.has($quad(ex.john, ex.is, ex.Imposter)));
+            })
+        });
     })
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,55 @@ require("./dataset/DatasetCore.test.js")(
     dataset: t => new (require('../dataset/index.js'))(t)
 });
 
-describe('StoreAlterer', function() {
+describe('DStar', function() {
+    describe('bindVariables', function() {
+        function _equalsPattern(pattern1, pattern2) {
+            if (Array.isArray(pattern1) && Array.isArray(pattern2)) {
+                if (pattern1.length != pattern2.length) {
+                    return false;
+                }
+        
+                for (let i = 0 ; i != pattern1.length ; ++i) {
+                    if (!_equalsPattern(pattern1[i], pattern2[i])) {
+                        return false;
+                    }
+                }
+        
+                return true;
+            } else if (!Array.isArray(pattern1) && !Array.isArray(pattern2)) {
+                return pattern1.equals(pattern2);
+            } else {
+                return false;
+            }
+        }
+
+        function equalsPattern(bind, source, expected) {
+            return _equalsPattern(
+                DStar.bindVariables(bind, source),
+                expected
+            );
+        }
+
+        it('should do nothing on empty patterns', function() {
+            assert.ok(equalsPattern({}                       , [], []));
+            assert.ok(equalsPattern({ "someNode": ex.SomeURI}, [], []));
+        })
+
+        it('should work', function() {
+            assert.ok(equalsPattern(
+                {},
+                [$quad(variable("a"), variable("b"), ex.object)],
+                [$quad(variable("a"), variable("b"), ex.object)]
+            ));
+
+            assert.ok(equalsPattern(
+                { a: ex.Value },
+                [$quad(variable("a"), variable("b"), ex.object)],
+                [$quad(ex.Value     , variable("b"), ex.object)]
+            ));
+        })
+    });
+
     describe("findFilterReplace", function() {
         it("should work", function() {
             const dstar = new DStar();


### PR DESCRIPTION
*PREC*:
- Meta Properties support
- Relationship model properly interact with meta properties (until a bug is disovered)
- With updated documentation

*DStar*
- Export bindVariables because it is usefull
- "evilFindAndReplace". It is evil because it is error prone and because it breaks referential opacity, leading to problems with no correct solution so it can also throw errors. (Probably should be renamed in a future commit)