### PR TITLE
Lists

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -684,8 +684,8 @@
               <li>`pvar:source`: The RDF node that represents the PG source node of the relationship.</li>
               <li>`pvar:destination`: The RDF node that represents the PG destination relationship.</li>
               <li>`pvar:relationshipIRI`: The RDF node that represents the label of the edge.</li>
-              <li>`pvar:propertyKey`: matchs every other predicates. Supposed to represent each property key.</li>
-              <li>`pvar:propertyValue`: matchs every other objects. Supposed to represent each property value.</li>
+              <li>`pvar:propertyKey`: matches every other predicates. Supposed to represent each property key.</li>
+              <li>`pvar:propertyValue`: matches every other objects. Supposed to represent each property value.</li>
             </ul>
 
             <p>
@@ -791,6 +791,7 @@
               <li>`pvar:propertyKey`: The node that represents the edge label.</li>
               <li>`pvar:property`: The blank node that represents the property.</li>
               <li>`pvar:propertyValue`: The literal that contains the property value.</li>
+              <li>`pvar:individualValue`: Most of the time equals to `propertyValue`. If `propertyValue` is an rdf list, `individualValue` will match each individual literal contained in the list instead of the list itself.</li>
               <li>`pvar:metaPropertyNode`: The blank node that contains every meta property, as described in [= prec:hasMetaProperties =]</li>
               <li>`pvar:metaPropertyKey`: The predicate of a meta property triple.</li>
               <li>`pvar:metaPropertyValue`: The object of a meta property triple.</li>

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "rdf-isomorphic": "^1.2.0"
     },
     "devDependencies": {
+        "@rdfjs/types": "^1.0.1",
         "mocha": "^8.3.2"
     }
 }

--- a/prec3/graph-reducer.js
+++ b/prec3/graph-reducer.js
@@ -591,8 +591,6 @@ const PropertyModelApplier = {
         let result = [];
         let currentList = propertyValue;
 
-        dataset.getQuads(null, null, currentList).forEach(q => console.error(q.subject));
-
         while (!rdf.nil.equals(currentList)) {
             let theLiteral = dataset.getQuads(currentList, rdf.first, null, defaultGraph());
             if (theLiteral.length !== 1)
@@ -609,8 +607,6 @@ const PropertyModelApplier = {
             currentList = nextElement;
         }
 
-        console.error(propertyValue);
-        console.error(result);
         return result;
     },
 

--- a/prec3/graph-reducer.js
+++ b/prec3/graph-reducer.js
@@ -2,7 +2,6 @@
 
 const N3            = require('n3');
 const DStar         = require('../dataset/index.js');
-const graphyFactory = require('@graphy/core.data.factory');
 const namespace     = require('@rdfjs/namespace');
 
 const Context       = require("./context-loader.js");
@@ -484,6 +483,7 @@ const PropertyModelApplier = {
                 [variable("propertyKey")      , pvar.propertyKey      ],
                 [variable("property")         , pvar.property         ],
                 [variable("propertyValue")    , pvar.propertyValue    ],
+                [variable("individualValue")  , pvar.individualValue  ],
                 [variable("metaPropertyNode") , pvar.metaPropertyNode ],
                 [variable("metaPropertyKey")  , pvar.metaPropertyKey  ],
                 [variable("metaPropertyValue"), pvar.metaPropertyValue],
@@ -493,53 +493,189 @@ const PropertyModelApplier = {
         // Split the pattern in 3 parts
         let pattern = r.reduce(
             (previous, quad) => {
+                let containerName = "";
+
                 if (quadStar.containsTerm(quad, variable("metaPropertyKey"))
-                    || quadStar.containsTerm(quad, variable("metaPropertyValue")))
-                    previous.metaValues.push(quad);
-                else if (quadStar.containsTerm(quad, variable("metaPropertyNode")))
-                    previous.optional.push(quad);
-                else
-                    previous.mandatory.push(quad);
+                    || quadStar.containsTerm(quad, variable("metaPropertyValue"))) {
+                    containerName = "metaValues";
+                } else if (quadStar.containsTerm(quad, variable("metaPropertyNode"))) {
+                    containerName = "optional";
+                } else {
+                    containerName = "mandatory";
+                }
+
+                if (quadStar.containsTerm(quad, variable("individualValue"))) {
+                    containerName += "Individual";
+                }
+
+                previous[containerName].push(quad);
                 
                 return previous;
             },
-            { mandatory: [], optional: [], metaValues: [] }
+            {
+                mandatory: [], optional: [], metaValues: [],
+                mandatoryIndividual: [], optionalIndividual: [], metaValuesIndividual: [],
+            }
         );
-    
-        let metaNodeIdentityQuads = dataset.getQuads(bindings.property, prec.hasMetaProperties, null, defaultGraph());
-    
-        if (metaNodeIdentityQuads.length === 0) {
-            // No match for hasMetaNode and hasMeta parts
-            // = no meta property
-            dataset.replaceOneBinding(bindings, pattern.mandatory);
-            return;
+
+        let addedQuads = [];
+        let deletedQuads = [];
+        
+        addedQuads.push(...DStar.bindVariables(bindings, pattern.mandatory));
+        deletedQuads.push(...bindings['@quads']);
+
+        const individualValues = PropertyModelApplier.extractIndividualValues(
+            dataset,
+            bindings.propertyValue,
+            pattern.mandatoryIndividual.length === 0
+            && pattern.optionalIndividual.length === 0
+            && pattern.metaValuesIndividual.length === 0
+        );
+
+        const metaProperties = PropertyModelApplier.findAndEraseMetaProperties(
+            dataset, context,
+            bindings.property,
+            pattern.optional.length === 0
+            && pattern.metaValues.length === 0
+            && pattern.optionalIndividual.length === 0
+            && pattern.metaValuesIndividual.length === 0
+        );
+
+        if (metaProperties !== null) {
+            deletedQuads.push(metaProperties.optionalPart['@quad']);
+
+            let q = DStar.bindVariables(bindings, pattern.optional);
+            q = DStar.bindVariables({ metaPropertyNode: metaProperties.optionalPart.metaPropertyNode }, q);
+            addedQuads.push(...q);
+            
+            q = DStar.bindVariables(bindings, pattern.metaValues);
+            q = DStar.bindVariables({ metaPropertyNode: metaProperties.optionalPart.metaPropertyNode }, q);
+            
+            metaProperties.metaValues.forEach(metaValue => {
+                const remadeQuads = q.map(modelQuad =>
+                    RelationshipModelApplier.remake(
+                        DStar.bindVariables(metaValue, modelQuad),
+                        metaValue['@depth'] - 1, metaValue['@quad']
+                    )
+                );
+
+                deletedQuads.push(metaValue['@quad']);
+                addedQuads.push(...remadeQuads);
+            })
         }
 
-        // We have to manage the meta property node
+        dataset.removeQuads(deletedQuads);
+        dataset.addAll(addedQuads);
+    },
+
+    extractIndividualValues: function(dataset, propertyValue, ignore) {
+        // TODO: the curernt rules to delete a list (if its individual values
+        // are read) is a bad solution. It would be better to check instead
+        // if the list is still used or not after transforming the property.
+        // Example of application: keeping both the list and storing the
+        // individual values for easier access
+        if (ignore === true) return [];
+
+        // A literal alone
+        if (propertyValue.termType === 'Literal') {
+            return [propertyValue];
+        }
+
+        // An RDF list
+        let result = [];
+        let currentList = propertyValue;
+
+        while (!rdf.nil.equals(currentList)) {
+            let theLiteral = dataset.getQuads(currentList, rdf.first, null, defaultGraph());
+            if (theLiteral.length !== 0)
+                throw Error(`Malformed list ${currentList.value}: ${theLiteral.length} values for rdf:first`);
+
+            result.push(theLiteral[0].object);
+
+            let theRest = dataset.getQuads(currentList, rdf.rest, null, defaultGraph());
+            if (theRest.length !== 0)
+                throw Error(`Malformed list ${currentList.value}: ${theRest.length} values for rdf:rest`);
+
+            let nextElement = theRest[0].object;
+            dataset.deleteMatches(currentList, null, null, defaultGraph());
+            currentList = nextElement;
+        }
+
+        return result;
+    },
+
+    findAndEraseMetaProperties: function(dataset, context, propertyNode, ignore) {
+        if (ignore === true) return null;
+
+        const metaNodeIdentityQuads = dataset.getQuads(propertyNode, prec.hasMetaProperties, null, defaultGraph());
+
+        if (metaNodeIdentityQuads.length === 0) return null;
+
         if (metaNodeIdentityQuads.length !== 1)
-            throw Error("Invalid data graph: more than one meta node for " + bindings.property.value);
+            throw Error("Invalid data graph: more than one meta node for " + propertyNode.value);
 
         const metaNode = metaNodeIdentityQuads[0].object;
-        
-        // Add the new found binding to the meta property node
-        bindings.metaPropertyNode = metaNode;
-        bindings['@quads'].push(metaNodeIdentityQuads[0]);
+
+        let result = {
+            optionalPart: {
+                "@quad": metaNodeIdentityQuads[0],
+                metaPropertyNode: metaNode
+            },
+            metaValues: []
+        };
 
         // Apply the meta property model to the meta property
+        // = setup the definitive ?metaPropertyNode ?metaPropertyKey ?metaPropertyValue triples
         PropertyModelApplier.transformMetaProperty(dataset, context, metaNode);
 
-        // Model the property
-        dataset.replaceOneBinding(bindings, pattern.mandatory);
-        bindings['@quads'] = [];
-        dataset.replaceOneBinding(bindings, pattern.optional);
-
-        // Remodel the meta properties
-        dataset.evilFindAndReplace(
-            bindings,
-            [ $quad(variable('metaPropertyNode'), variable('metaPropertyKey'), variable('metaPropertyValue')) ],
-            pattern.metaValues
+        // Extract the ?mPN ?mPK ?mPV values
+        const mPNmPKmPV = dataset.getQuads(
+            /* ?metaPropertyNode  */ metaNode,
+            /* ?metaPropertyKey   */ null,
+            /* ?metaPropertyValue */ null,
+            defaultGraph()
         );
+
+        let everyRdfStarQuads = dataset.getRDFStarQuads();
+
+        result.metaValues = mPNmPKmPV.map(quad => {
+            return {
+                "@quad": quad,
+                "@depth": 0,
+                metaPropertyKey: quad.predicate,
+                metaPropertyValue: quad.object
+            };
+        })
+
+        for (const rdfStarQuad of everyRdfStarQuads) {
+            let depth = 1;
+
+            let currentTerm = rdfStarQuad.subject;
+
+            while (currentTerm.termType === 'Quad') {
+                let isMine = mPNmPKmPV.find(e => currentTerm.equals(e));
+
+                if (isMine !== undefined) {
+                    result.metaValues.push(
+                        {
+                            "@quad": rdfStarQuad,
+                            "@depth": depth,
+                            metaPropertyKey: isMine.predicate,
+                            metaPropertyValue: isMine.object
+                        }
+                    )
+
+                    break;
+                }
+
+                currentTerm = currentTerm.subject;
+                ++depth;
+            }
+        }
+
+        return result;
     }
+
 }
 
 

--- a/prec3/quad-star.js
+++ b/prec3/quad-star.js
@@ -3,6 +3,11 @@
 const N3 = require('n3');
 
 /**
+ * @typedef { import("rdf-js").Term } Term
+ * @typedef { import("rdf-js").Quad } Quad
+ */
+
+/**
  * Returns a quad equals to
  * ```
  *  Quad(
@@ -82,9 +87,47 @@ function containsTerm(term, searched) {
         || containsTerm(term.graph    , searched);
 }
 
+/**
+ * Checks if realQuad and patternQuad are equals. `null` and `undefined` are
+ * considered wildcards: any term matches it in the pattern quad.
+ * 
+ * `realQuad` must not contain any wildcard
+ * 
+ * @param {Quad} realQuad A quad with no wildcards
+ * @param {Quad} patternQuad A quad that may contain wildcards
+ * @returns {boolean} True if the readQuad matches the patternQuad
+ */
+function matches(realQuad, patternQuad) {
+    for (const position of ['subject', 'predicate', 'object', 'graph']) {
+        const rightTerm = patternQuad[position];
+        if (rightTerm === null || rightTerm === undefined) {
+            continue;
+        }
+
+        const leftTerm = realQuad[position];
+
+        if (rightTerm.termType === 'Quad') {
+            if (leftTerm.termType !== 'Quad') {
+                return false;
+            }
+
+            if (!matches(leftTerm, rightTerm)) {
+                return false;
+            }
+        } else {
+            if (!leftTerm.equals(rightTerm)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
 
 module.exports = {
     eventuallyRebuildQuad,
     remapPatternWithVariables,
-    containsTerm
+    containsTerm,
+    matches
 };

--- a/test/prec_context.js
+++ b/test/prec_context.js
@@ -638,6 +638,17 @@ describe("Property convertion", function() {
 
 
 describe("Relationship and Property convertion", function() {
+    const anEdge =
+    `
+        :source      a pgo:Node .
+        :destination a pgo:Node .
+
+        :edge rdf:subject   :source       ;
+              rdf:predicate :predicate    ;
+              rdf:object    :destination  ;
+              rdf:type      pgo:Edge      ;
+    `;
+
     const graphs = {
         edgeWithMetaProperty: `
             :source      a pgo:Node .
@@ -693,6 +704,34 @@ describe("Relationship and Property convertion", function() {
             [] a prec:PropertyRule ;
                 prec:propertyName "Property 2" ;
                 prec:propertyIRI  :Z_SECOND .
+        `,
+
+        edgeWithList:
+            //anEdge +
+        `
+            :node a pgo:Node ; :property :property_bn .
+            :property a prec:Property, prec:CreatedProperty ; rdfs:label "Property" .
+            :property_bn a prec:PropertyValue ; rdf:value ( "A" "B" "C" "D" "E" ) .
+
+            :property_bn prec:hasMetaProperties :meta_property_bn .
+
+            :meta_property_bn :property :numbers_bn .
+            :numbers_bn a prec:PropertyValue ; rdf:value ( 1 2 3 ) .
+        `,
+        cartesianProductOfMetaLists:
+        `
+            prec:Properties     prec:modelAs prec:CartesianProduct .
+            prec:KeepProvenance prec:flagState false .
+        
+            prec:CartesianProduct a prec:PropertyModel ;
+                prec:composedOf
+                       << pvar:entity pvar:propertyKey pvar:individualValue >> ,
+                    << << pvar:entity pvar:propertyKey pvar:individualValue >> pvar:metaPropertyKey pvar:metaPropertyValue >> .
+                
+            [] a prec:PropertyRule ;
+                prec:propertyName "Property" ;
+                prec:propertyIRI :element .
+            
         `
     };
 
@@ -721,6 +760,30 @@ describe("Relationship and Property convertion", function() {
             <<    :edge                                :Z_SECOND "Value 2" >> :Z_FIRST "TheMetaProperty" .
         `
     );
-        
+
+    runATest_(graphs, 'edgeWithList', 'cartesianProductOfMetaLists',
+    `
+           <http://test/node> <http://test/element> "A" .
+           <http://test/node> <http://test/element> "B" .
+           <http://test/node> <http://test/element> "C" .
+           <http://test/node> <http://test/element> "D" .
+           <http://test/node> <http://test/element> "E" .
+        << <http://test/node> <http://test/element> "A" >> <http://test/element> "1" .
+        << <http://test/node> <http://test/element> "B" >> <http://test/element> "1" .
+        << <http://test/node> <http://test/element> "C" >> <http://test/element> "1" .
+        << <http://test/node> <http://test/element> "D" >> <http://test/element> "1" .
+        << <http://test/node> <http://test/element> "E" >> <http://test/element> "1" .
+        << <http://test/node> <http://test/element> "A" >> <http://test/element> "2" .
+        << <http://test/node> <http://test/element> "B" >> <http://test/element> "2" .
+        << <http://test/node> <http://test/element> "C" >> <http://test/element> "2" .
+        << <http://test/node> <http://test/element> "D" >> <http://test/element> "2" .
+        << <http://test/node> <http://test/element> "E" >> <http://test/element> "2" .
+        << <http://test/node> <http://test/element> "A" >> <http://test/element> "3" .
+        << <http://test/node> <http://test/element> "B" >> <http://test/element> "3" .
+        << <http://test/node> <http://test/element> "C" >> <http://test/element> "3" .
+        << <http://test/node> <http://test/element> "D" >> <http://test/element> "3" .
+        << <http://test/node> <http://test/element> "E" >> <http://test/element> "3" .
+    `
+);
 
 })

--- a/test/prec_context.js
+++ b/test/prec_context.js
@@ -768,21 +768,21 @@ describe("Relationship and Property convertion", function() {
            <http://test/node> <http://test/element> "C" .
            <http://test/node> <http://test/element> "D" .
            <http://test/node> <http://test/element> "E" .
-        << <http://test/node> <http://test/element> "A" >> <http://test/element> "1" .
-        << <http://test/node> <http://test/element> "B" >> <http://test/element> "1" .
-        << <http://test/node> <http://test/element> "C" >> <http://test/element> "1" .
-        << <http://test/node> <http://test/element> "D" >> <http://test/element> "1" .
-        << <http://test/node> <http://test/element> "E" >> <http://test/element> "1" .
-        << <http://test/node> <http://test/element> "A" >> <http://test/element> "2" .
-        << <http://test/node> <http://test/element> "B" >> <http://test/element> "2" .
-        << <http://test/node> <http://test/element> "C" >> <http://test/element> "2" .
-        << <http://test/node> <http://test/element> "D" >> <http://test/element> "2" .
-        << <http://test/node> <http://test/element> "E" >> <http://test/element> "2" .
-        << <http://test/node> <http://test/element> "A" >> <http://test/element> "3" .
-        << <http://test/node> <http://test/element> "B" >> <http://test/element> "3" .
-        << <http://test/node> <http://test/element> "C" >> <http://test/element> "3" .
-        << <http://test/node> <http://test/element> "D" >> <http://test/element> "3" .
-        << <http://test/node> <http://test/element> "E" >> <http://test/element> "3" .
+        << <http://test/node> <http://test/element> "A" >> <http://test/element> 1 .
+        << <http://test/node> <http://test/element> "B" >> <http://test/element> 1 .
+        << <http://test/node> <http://test/element> "C" >> <http://test/element> 1 .
+        << <http://test/node> <http://test/element> "D" >> <http://test/element> 1 .
+        << <http://test/node> <http://test/element> "E" >> <http://test/element> 1 .
+        << <http://test/node> <http://test/element> "A" >> <http://test/element> 2 .
+        << <http://test/node> <http://test/element> "B" >> <http://test/element> 2 .
+        << <http://test/node> <http://test/element> "C" >> <http://test/element> 2 .
+        << <http://test/node> <http://test/element> "D" >> <http://test/element> 2 .
+        << <http://test/node> <http://test/element> "E" >> <http://test/element> 2 .
+        << <http://test/node> <http://test/element> "A" >> <http://test/element> 3 .
+        << <http://test/node> <http://test/element> "B" >> <http://test/element> 3 .
+        << <http://test/node> <http://test/element> "C" >> <http://test/element> 3 .
+        << <http://test/node> <http://test/element> "D" >> <http://test/element> 3 .
+        << <http://test/node> <http://test/element> "E" >> <http://test/element> 3 .
     `
 );
 

--- a/test/quad-star.js
+++ b/test/quad-star.js
@@ -1,0 +1,79 @@
+const assert = require('assert');
+
+const N3 = require('n3');
+const namespace = require('@rdfjs/namespace');
+const ex = namespace("http://ex.org/", N3.DataFactory);
+const $Quad = N3.DataFactory.quad;
+
+const QuadStar = require('../prec3/quad-star');
+
+
+describe('QuadStar', function () {
+	describe('matches', function () {
+		it('should work for non RDF-star quads', function () {
+			assert.ok(
+				QuadStar.matches(
+					$Quad(ex.a, ex.b, ex.c),
+					$Quad(ex.a, ex.b, ex.c),
+				)
+			);
+
+			assert.ok(
+				QuadStar.matches(
+					$Quad(ex.a, ex.b, ex.c),
+					$Quad(ex.a, ex.b, null),
+				)
+			);
+			
+			assert.ok(
+				!QuadStar.matches(
+					$Quad(ex.a, ex.different, ex.object),
+					$Quad(ex.a, ex.b        , ex.object),
+				)
+			);
+
+			assert.ok(
+				!QuadStar.matches(
+					$Quad(ex.a, ex.different, ex.c),
+					$Quad(ex.a, ex.b        , null),
+				)
+			);
+		});
+
+		it('should work with RDF-star', function () {
+
+			assert.ok(
+				QuadStar.matches(
+					$Quad($Quad(ex.s, ex.p, ex.o), ex.b, ex.c),
+					$Quad($Quad(ex.s, ex.p, ex.o), ex.b, ex.c),
+				)
+			);
+
+			assert.ok(
+				!QuadStar.matches(
+					$Quad($Quad(ex.s, ex.p, ex.o), ex.b, ex.c),
+					$Quad($Quad(ex.s, ex.p, ex.X), ex.b, ex.c),
+				)
+			);
+
+			assert.ok(
+				QuadStar.matches(
+					$Quad($Quad(ex.s, ex.p, ex.o), ex.b, ex.c),
+					$Quad($Quad(ex.s, ex.p, null), ex.b, ex.c),
+				)
+			);
+			
+			assert.ok(
+				!QuadStar.matches(
+					$Quad(       ex.spo          , ex.b, ex.c),
+					$Quad($Quad(ex.s, ex.p, null), ex.b, ex.c),
+				)
+			);
+		})
+	});
+
+
+
+})
+
+

--- a/test/test.js
+++ b/test/test.js
@@ -304,6 +304,46 @@ describe('DStar', function() {
             })
         });
     })
+
+    describe("allUsageOfAre", function () {
+        it('test1', function () {
+            const dstar = new DStar();
+            dstar.addFromTurtleStar(
+                `
+                @prefix ex:  <http://example.org/> .
+                @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                
+                ex:subject ex:predicate1 ex:object .
+                ex:subject ex:predicate2 ex:object .
+                ex:other ex:predicate1 ex:object .
+                `
+            );
+
+            assert.ok(
+                dstar.allUsageOfAre(ex.subject,
+                    [
+                        $quad(ex.subject, null, ex.object)
+                    ]
+                ) !== null
+            );
+
+            assert.ok(
+                dstar.allUsageOfAre(ex.other,
+                    [
+                        $quad(ex.other, null, null)
+                    ]
+                ) !== null
+            );
+
+            assert.ok(
+                dstar.allUsageOfAre(ex.object,
+                    [
+                        $quad(ex.other, null, ex.object)
+                    ]
+                ) === null
+            );
+        })
+    });
 });
 
 


### PR DESCRIPTION
Introduction of `pvar:individualValue` in `prec:PropertyModel`

- `pvar:individualValue` matches:
    - The property value if it is a basic type (int, string). For example in the property graph node `[ { name: "Toto" } ]`, it will match `"Toto"` for the property name
    - Every contained value if the value of the property is a list. For example `[ {name: [ "Mickael", "Mike" ] } ]` will match one time with `"Mickael"` and one time with `"Mike"`

TODO before merging:
- [ ] ~~More tests~~ (The tests need a major rehaul)
- [x] In particular, test combinaison of pvar:propertyValue and pvar:individualValue
    - [x] This involves having a more fined grain of when to delete or not delete the list from the data graph
- [x] Update the documentation of the ontology

